### PR TITLE
Defer Application.Init call

### DIFF
--- a/YTSubConverter.UI.Linux/Program.cs
+++ b/YTSubConverter.UI.Linux/Program.cs
@@ -7,13 +7,13 @@ namespace YTSubConverter.UI.Linux
     {
         public static void Main(string[] args)
         {
-            Application.Init();
             if (args.Length > 0)
             {
                 CommandLineHandler.Handle(args);
                 return;
             }
 
+            Application.Init();
             new MainWindow().Show();
             Application.Run();
         }


### PR DESCRIPTION
Currently the Linux version of the program does not work on machines without a display. Instead when trying to run it these messages will pop up.
```
Unable to init server: Could not connect: Connection refused

(YTSubConverter:12278): Gtk-WARNING **: 12:07:36.552: cannot open display:
```

This PR aims to fix this by moving the Application.Init call after the command line program check.
After this change the above error messages don't appear and the program converts the subtitles successfully.
This change should not affect how the GUI works on Linux but I am unable to test that.