### PR TITLE
AssStyleOptionsList: Fix build regression by changing access type of …

### DIFF
--- a/YTSubConverter.Shared/AssStyleOptionsList.cs
+++ b/YTSubConverter.Shared/AssStyleOptionsList.cs
@@ -69,7 +69,7 @@ namespace YTSubConverter.Shared
             serializer.Serialize(stream, list);
         }
 
-        private static string GetDefaultFilePath()
+        public static string GetDefaultFilePath()
         {
             return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), FileName);
         }


### PR DESCRIPTION
…GetDefaultFilePath() to public

Prevents error CS0117: 'AssStyleOptionsList' does not contain a definition for 'GetDefaultFilePath' in YTSubConverter.UI.Linux/MainWindow.cs(524,51).

(the regression was introduced by 1ca562e22b8d0bcf717f54d30a2ebaa101974ac8)

I don't have much experience doing actual programming but I thought it would be fun to try and fix this error because it appears to be a simple fix lol, pretty sure I got it right

This PR builds without the above error and the feature in 1ca562e22b8d0bcf717f54d30a2ebaa101974ac8 works properly, thanks!