### PR TITLE
Linux: conform style options file to the XDG base directory specification

### DIFF
--- a/YTSubConverter.UI.Linux/MainWindow.cs
+++ b/YTSubConverter.UI.Linux/MainWindow.cs
@@ -525,8 +525,9 @@ namespace YTSubConverter.UI.Linux
             if (File.Exists(filePath))
                 return filePath;
 
-            string homeFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            return System.IO.Path.Combine(homeFolderPath, ".config", "ytsubconverter", AssStyleOptionsList.FileName);
+            string configDir = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME") ??
+                               System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config");
+            return System.IO.Path.Combine(configDir, "ytsubconverter", AssStyleOptionsList.FileName);
         }
     }
 }


### PR DESCRIPTION
Falls back to ~/.config/ytsubconverter if the host doesn't define a directory for configuration files with XDG.