### PR TITLE
Defer GUI initialization to allow running on headless Linux environments

### DIFF
--- a/YTSubConverter.UI.Linux/Program.cs
+++ b/YTSubConverter.UI.Linux/Program.cs
@@ -7,14 +7,16 @@ namespace YTSubConverter.UI.Linux
     {
         public static void Main(string[] args)
         {
-            Application.Init("ytsubconverter", ref args);
             if (args.Length > 0)
             {
                 using GtkTextMeasurer textMeasurer = new();
                 CommandLineHandler.Handle(args, textMeasurer);
                 return;
             }
-            
+
+            // Initialize application only after checking checking if the application is run as a command line app.
+            // Useful in headless environments, e.g. VMs.
+            Application.Init("ytsubconverter", ref args);
             using var window = new MainWindow();
             window.Show();
             Application.Run();


### PR DESCRIPTION
The purpose of this change is to allow the app to be run in headless environments. When using the app as a command line executable (e.g. `ytsubconverter in.srv3 out.ass --visual`), the app exits in headless environments with the message "cannot open display". 

The application GUI initialization is deferred so it is run only if no command line parameters were given. This should ensure that the app can be used as a command line only executable in headless environments. I personally use this project in my video archiving app that runs on a VM that has no displays.